### PR TITLE
Display can depths in a modal

### DIFF
--- a/modules/ducs/client/controllers/admin-list.client.controller.js
+++ b/modules/ducs/client/controllers/admin-list.client.controller.js
@@ -52,5 +52,21 @@
       else
         return "Fail";
     };
+
+    $scope.showDepths = function(depths) {
+      //console.log("show depths");
+      var modal = document.getElementById("depthsModal");
+      var modalBody = document.getElementById("modalBody");
+      modalBody.innerHTML = "<p>" + depths + "</p>";
+      modal.style.display = "block"; //make modal visible
+      //$("depthsModal").modal('show');
+    }
+
+    $scope.closeModal = function() {
+      //console.log("close modal");
+      var modal = document.getElementById("depthsModal");
+      modal.style.display = "none";
+      //$("depthsModal").modal('hide');
+    }
   }
 }());

--- a/modules/ducs/client/controllers/admin-map.client.controller.js
+++ b/modules/ducs/client/controllers/admin-map.client.controller.js
@@ -5,10 +5,21 @@
     .module('ducs')
     .controller('AdminMapController', AdminMapController);
 
-  AdminMapController.$inject = ['DucsService'];
+  AdminMapController.$inject = ['$scope', 'DucsService'];
 
-  function AdminMapController(DucsService) {
+  function AdminMapController($scope, DucsService) {
     var vm = this;
-    console.log("Map controller loaded");
+    DucsService.getCountyCounts()
+    .then(function(response) {
+        vm.countyCounts = response.data;
+
+        $scope.total = 0;
+        for (var key in vm.countyCounts) {
+          $scope.total += vm.countyCounts[key].count;
+        }
+      }, function(error) {
+        //otherwise display the error
+        $scope.error = 'Couldn\'t load measurement data!\n err:' + error;
+      });
   }
 }());

--- a/modules/ducs/client/services/ducs.client.service.js
+++ b/modules/ducs/client/services/ducs.client.service.js
@@ -23,9 +23,12 @@
         return $http.delete('/api/measurements/' + measurement);
       },
 
-      email: function(id, data){
+      email: function(id, data) {
         return $http.post('/api/email-result/' + id, data);
+      },
 
+      getCountyCounts: function() {
+        return $http.get('/api/measurements/count');
       }
     };
 

--- a/modules/ducs/client/views/admin.list-ducs.client.view.html
+++ b/modules/ducs/client/views/admin.list-ducs.client.view.html
@@ -27,8 +27,8 @@
               <td>{{getResult(m.results.uniformity_distribution)}}</td>
               <td>{{m.results.uniformity_distribution}}</td>
               <td>{{m.results.irrigation_rate}}</td>
-              <td ng-if="m.can_depths.length < 6">{{m.can_depths}}</td>
-              <td style="overflow: scroll" ng-if="m.can_depths.length >= 5">Now that's what I call big data</td>
+              <td ng-if="m.can_depths.length < 10">{{m.can_depths}}</td>
+              <td ng-if="m.can_depths.length >= 10"><button class="btn btn-default" ng-click="showDepths(m.can_depths);">View</button></td>
               <td>{{m.user.email}}</td>
               <td>{{formatDate(m.created_at)}}</td>
               <td>
@@ -40,4 +40,16 @@
         </tbody>
       </table>
     </div>
+    <div id="depthsModal" class="modal fade in" style="display: none; float: left; top: 50%;">
+        <div class="modal-dialogue">
+          <div class="modal-content">
+            <div class="modal-header">
+              <button type="button" class="close" ng-click="closeModal()">Close</button>
+              <h4 class="modal-title" id="modalTitle">Can Depths</h4>
+            </div>
+            <div class="modal-body" id="modalBody">
+            </div>
+          </div>
+        </div>
+      </div>
 </section>

--- a/modules/ducs/client/views/admin.map.client.view.html
+++ b/modules/ducs/client/views/admin.map.client.view.html
@@ -1,6 +1,21 @@
 <section>
     <div class="page-header">
-      <h1>Ducs Admin</h1>
+      <h1>DUC Stats</h1>
     </div>
-    <div LGMap></div>
+    <table class="table table-striped">
+        <thead>
+            <td>County</td>
+            <td>Number of Measurements</td>
+        </thead>
+        <tbody>
+            <tr ng-repeat="m in vm.countyCounts">
+              <td>{{m._id}}</td>
+              <td>{{m.count}}</td>
+            </tr>
+            <tr>
+              <td><b>Total Measurements</b></td>
+              <td><b>{{total}}</b></td>
+            </tr>
+        </tbody>
+    </table>
 </section>

--- a/modules/ducs/server/controllers/measurements.controller.js
+++ b/modules/ducs/server/controllers/measurements.controller.js
@@ -193,6 +193,16 @@ exports.list = function(req, res) {
 
 };
 
+exports.getCountyCounts = function(req, res) {
+  Measurement.aggregate([{"$group": {_id:"$county", count:{$sum:1}}}]).sort({'count': -1}).exec(function(err, countyCount) {
+    if (err) {
+      res.status(400).send(err);
+    } else {
+      res.json(countyCount);
+    }
+  });
+};
+
 /**
  * Show the current Duc
  */

--- a/modules/ducs/server/routes/measurements.server.routes.js
+++ b/modules/ducs/server/routes/measurements.server.routes.js
@@ -14,8 +14,9 @@ module.exports = function(app) {
     app.route('/api/measurements')
       .get(measurements.list)
       .post(measurements.county, measurements.city, measurements.create);
-    
-      
+
+    app.route('/api/measurements/count')
+      .get(measurements.getCountyCounts);
 
     app.route('/api/measurements/:measureId')
       .get(measurements.read)


### PR DESCRIPTION
When there are too many can depths, the admin measurement list view layout gets messed up.
After this change, if a measurement has more than 10 cans, the list of depths is replaced with a "view" button. Clicking that button displays a popup window with all of the can depths.